### PR TITLE
saving progress

### DIFF
--- a/src/components/app.js
+++ b/src/components/app.js
@@ -11,7 +11,7 @@ import Privacy from '../routes/privacy';
 import Terms from '../routes/terms';
 
 export default class App extends Component {
-	
+
 	/** Gets fired when the route changes.
 	 *	@param {Object} event		"change" event from [preact-router](http://git.io/preact-router)
 	 *	@param {string} event.url	The newly routed URL
@@ -20,17 +20,30 @@ export default class App extends Component {
 		this.currentUrl = e.url;
 	};
 
+	searchToObject = (search) => {
+		return search.substring(1).split('&').reduce((result, value) => {
+			const parts = value.split('=');
+			if (parts[0]) result[decodeURIComponent(parts[0])] = decodeURIComponent(parts[1]);
+			return result;
+		}, {});
+	};
+
+	constructor(props) {
+		super(props);
+		this.params = this.searchToObject(location.search);
+	}
+
 	//Fix Footer styling
 	render() {
 		return (
 			<div id="app">
 				<Header />
-				<Router onChange={this.handleRoute}>
+				<Router onChange={this.handleRoute} params={this.params}>
 					<Form path="/" />
-					<Exit path="/thank-you/"/>
-					<About path="/about/"/>
-					<Privacy path="/privacy/"/>
-					<Terms path="/terms/"/>
+					<Exit path="/thank-you/" />
+					<About path="/about/" />
+					<Privacy path="/privacy/" />
+					<Terms path="/terms/" />
 				</Router>
 				<Footer />
 			</div>

--- a/src/components/footer/index.js
+++ b/src/components/footer/index.js
@@ -4,14 +4,14 @@ import { Link } from 'preact-router/match';
 //TODO: Actual footer, Google Tag Manager, Dynamic Year
 const Footer = () => (
 	<div class="footer">
-	   <p>© GetMyHealthcare 2019. All rights reserved.</p>
+	   <p>&copy; GetMyHealthcare 2019. All rights reserved.</p>
 	   <nav>
 	     <ul>
-	       <li>Privacy Policy</li>
-	       <li>Terms of Use</li>
-	       <li>About Us</li>
+	       <li><Link href="/privacy/">Privacy Policy</Link></li>
+	       <li><Link href="/terms/">Terms of Use</Link></li>
+	       <li><Link href="/about/">About Us</Link></li>
 	     </ul>
-	   </nav> 
+	   </nav>
 	 </div>
 );
 

--- a/src/components/header/index.js
+++ b/src/components/header/index.js
@@ -2,12 +2,12 @@ import { h } from 'preact';
 import { Link } from 'preact-router/match';
 
 const Header = () => (
-	<header class='header'>
-		<img src="/assets/getmyhealthcare-logo.svg"/>  
+	<header class="header">
+		<Link href="/"><img src="/assets/getmyhealthcare-logo.svg" /></Link>
 		<nav>
 			<ul>
 				<li><Link href="/">Home</Link></li>
-			</ul>	
+			</ul>
 		</nav>
 	</header>
 );

--- a/src/routes/form/PageFive.js
+++ b/src/routes/form/PageFive.js
@@ -26,41 +26,41 @@ const PageFive = props => (
 		  <h2>Just need to confirm contact details for your quote estimates</h2>
 		  <p>Complete this paege and we’ll match you with available plans and show you estimated pricing including subsidies</p>
 		</div>
-		<label htmlFor="firstName" name="firstName">First Name</label>
-		<Field name="firstName" placeholder="First Name" type="text" />
+		<label htmlFor="name_first" name="name_first">First Name</label>
+		<Field name="name_first" placeholder="First Name" type="text" />
 		<ErrorMessage
-		  name="firstName"
+		  name="name_first"
 		  component="div"
 		  className="field-error"
 		/>
 
-		<label htmlFor="lastName" name="lastName">Last Name</label>
-		<Field name="lastName" placeholder="Last Name" type="text" />
-		<ErrorMessage 
-		  name="lastName"
+		<label htmlFor="name_last" name="name_last">Last Name</label>
+		<Field name="name_last" placeholder="Last Name" type="text" />
+		<ErrorMessage
+		  name="name_last"
 		  component="div"
 		  className="field-error"
 		/>
 
-		<label htmlFor="streetAddress" name="streetAddress">Street Address</label>
-		<Field name="streetAddress" placeholder="123 Main St" type="text" />
-		<ErrorMessage 
-		  name="streetAddress" 
-		  component="div" 
+		<label htmlFor="home_street" name="home_street">Street Address</label>
+		<Field name="home_street" placeholder="123 Main St" type="text" />
+		<ErrorMessage
+		  name="home_street"
+		  component="div"
 		  className="field-error"
 		/>
 
 		<label htmlFor="email" name="email">Email</label>
 		<Field name="email" placeholder="email@address.com" type="email" />
-		<ErrorMessage 
-		  name="email" 
-		  component="div" 
+		<ErrorMessage
+		  name="email"
+		  component="div"
 		  className="field-error"
 		/>
 
-		<label htmlFor="phone" name="phone">Phone</label>
+		<label htmlFor="phone_home" name="phone_home">Phone</label>
 		<Field
-              name="phone"
+              name="phone_home"
               render={({ field }) => (
                 <MaskedInput
                   {...field}
@@ -70,14 +70,14 @@ const PageFive = props => (
                 />
               )}
             />
-		<ErrorMessage 
-		  name="phone" 
-		  component="div" 
+		<ErrorMessage
+		  name="phone"
+		  component="div"
 		  className="field-error"
 		/>
 		<button
 			type="submit"
-			disabled={!(props.values.firstName && props.values.lastName && props.values.streetAddress && props.values.email && props.values.phone)}
+			disabled={!(props.values.name_first && props.values.name_last && props.values.home_street && props.values.email && props.values.phone_home)}
 		>
 			Submit
 		</button>

--- a/src/routes/form/PageFour.js
+++ b/src/routes/form/PageFour.js
@@ -11,6 +11,7 @@ const PageThree = props => (
 		</div>
 		<label htmlFor="coverageType" name="coverageType">Coverage type</label>
 		<Field htmlFor="coverageType" placholder="Coverage type" component="select" name="coverageType">
+			<option value="">Select</option>
 		  <option value="Bronze" name="coverageType">Bronze</option>
 		  <option value="Silver" name="coverageType">Silver</option>
 		  <option value="Gold" name="coverageType">Gold</option>

--- a/src/routes/form/PageOne.js
+++ b/src/routes/form/PageOne.js
@@ -23,14 +23,15 @@ const PageOne = props => (
 		    <div class="input-group">
 	            <label htmlFor="numberOnPolicy" name="numberOnPolicy" >Number on Policy</label>
 	            <Field htmlFor="numberOnPolicy" name="numberOnPolicy" component="select" placeholder="1">
-	              <option value="1" selected>1</option>
-	              <option value="2" >2</option>
-	              <option value="3" >3</option>
-	              <option value="4+" >4+</option>
+	              <option value="">Select</option>
+	              <option value="1">1</option>
+	              <option value="2">2</option>
+	              <option value="3">3</option>
+	              <option value="4+">4+</option>
 	            </Field>
-	            <label htmlFor="zip" name="zip">Zip Code</label>
+	            <label htmlFor="home_zip" name="home_zip">Zip Code</label>
 	          <Field
-	                    name="zip"
+	                    name="home_zip"
 	                    render={({ field }) => (
 	                      <MaskedInput
 	                        {...field}
@@ -43,7 +44,7 @@ const PageOne = props => (
 	            <button
 	              type="button"
 	              onClick={props.navigateNext}
-	              disabled={!(props.values.numberOnPolicy && props.values.zip)}
+	              disabled={!(props.values.numberOnPolicy && props.values.home_zip)}
 	            >
 	              Next
 	            </button>
@@ -57,14 +58,14 @@ const PageOne = props => (
 	              component="div"
 	              className="field-error"
 	            />
-		    </div>   
+		    </div>
 		  </div>
 		  <div class="plans">
 		    <nav>
 		      <ul>
 		        <li>
 		          <img src="/assets/pill-icon.svg" alt="Obamacare Plans"/>
-		          <p>Obamacare Plans</p> 
+		          <p>Obamacare Plans</p>
 		        </li>
 		        <li>
 		          <img src="/assets/life-case.svg" alt="Medicare Plans"/>
@@ -79,7 +80,7 @@ const PageOne = props => (
 		          <p>Health Plans</p>
 		        </li>
 		      </ul>
-		    </nav> 
+		    </nav>
 		  </div>
 		  <div class="about">
 		   <h3>Everything you need for your health insurance choices in one place!</h3>
@@ -128,7 +129,7 @@ const PageOne = props => (
 	              component="div"
 	              className="field-error"
 	            />
-		    </div>   
+		    </div>
 			   </div>
 			  </div>
 			  <div class="stats">
@@ -140,18 +141,19 @@ const PageOne = props => (
 			    <h3>We’ve helped XXXXX of Americans shop for Helathcare</h3>
 			    <p>“Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed justo neque, feugiat sit amet lacus in, dapibus convallis ligula. Vivamus ornare sed ligula sed porta.”<br/><br/>- Some Person</p>
 			    <p>“In hac habitasse platea dictumst. Mauris laoreet massa et nibh dapibus bibendum. Nunc mauris nulla, tincidunt in tristique.”<br/><br/>- Some Person</p>
-		    	   
+
 		    	    <div class="input-group">
 	            <label htmlFor="numberOnPolicy" name="numberOnPolicy" >Number on Policy</label>
 	            <Field htmlFor="numberOnPolicy" name="numberOnPolicy" component="select" placeholder="1">
-	              <option value="1" selected>1</option>
-	              <option value="2" >2</option>
-	              <option value="3" >3</option>
-	              <option value="4+" >4+</option>
+	              <option value="">Select</option>
+	              <option value="1">1</option>
+	              <option value="2">2</option>
+	              <option value="3">3</option>
+	              <option value="4+">4+</option>
 	            </Field>
-	            <label htmlFor="zip" name="zip">Zip Code</label>
+	            <label htmlFor="home_zip" name="home_zip">Zip Code</label>
 	          <Field
-	                    name="zip"
+	                    name="home_zip"
 	                    render={({ field }) => (
 	                      <MaskedInput
 	                        {...field}
@@ -164,7 +166,7 @@ const PageOne = props => (
 	            <button
 	              type="button"
 	              onClick={props.navigateNext}
-	              disabled={!(props.values.numberOnPolicy && props.values.zip)}
+	              disabled={!(props.values.numberOnPolicy && props.values.home_zip)}
 	            >
 	              Next
 	            </button>
@@ -178,8 +180,8 @@ const PageOne = props => (
 	              component="div"
 	              className="field-error"
 	            />
-		    </div>   
-			  </div> 
+		    </div>
+			  </div>
 			</main>
 	</div>
 );

--- a/src/routes/form/PageOne.js
+++ b/src/routes/form/PageOne.js
@@ -4,13 +4,7 @@ import * as Yup from 'yup';
 import MaskedInput from 'react-text-mask';
 //import zipSubmit from '../../components/zip-submit';
 
-const zipMask = [
-  /[1-9]/,
-  /\d/,
-  /\d/,
-  /\d/,
-  /\d/,
-];
+const zipMask = [ /[1-9]/, /\d/, /\d/, /\d/, /\d/ ];
 
 // TODO Make ZipSubmit component (onClick send to top of page)
 const PageOne = props => (
@@ -54,7 +48,7 @@ const PageOne = props => (
 	              className="field-error"
 	            />
 	            <ErrorMessage
-	              name="zip"
+	              name="home_zip"
 	              component="div"
 	              className="field-error"
 	            />
@@ -64,19 +58,19 @@ const PageOne = props => (
 		    <nav>
 		      <ul>
 		        <li>
-		          <img src="/assets/pill-icon.svg" alt="Obamacare Plans"/>
+		          <img src="/assets/pill-icon.svg" alt="Obamacare Plans" />
 		          <p>Obamacare Plans</p>
 		        </li>
 		        <li>
-		          <img src="/assets/life-case.svg" alt="Medicare Plans"/>
+		          <img src="/assets/life-case.svg" alt="Medicare Plans" />
 		          <p>Short-term Plans</p>
 		        </li>
 		        <li>
-		          <img src="/assets/heart-beat.svg" alt="Medicare Plans"/>
+		          <img src="/assets/heart-beat.svg" alt="Medicare Plans" />
 		          <p>Medicare Plans</p>
 		        </li>
 		        <li>
-		          <img src="/assets/Laptop Icon.svg" alt="Health Plans"/>
+		          <img src="/assets/Laptop Icon.svg" alt="Health Plans" />
 		          <p>Health Plans</p>
 		        </li>
 		      </ul>
@@ -95,14 +89,15 @@ const PageOne = props => (
      	   <div class="input-group">
 	            <label htmlFor="numberOnPolicy" name="numberOnPolicy" >Number on Policy</label>
 	            <Field htmlFor="numberOnPolicy" name="numberOnPolicy" component="select" placeholder="1">
-	              <option value="1" selected>1</option>
-	              <option value="2" >2</option>
-	              <option value="3" >3</option>
-	              <option value="4+" >4+</option>
+								<option value="">Select</option>
+	              <option value="1">1</option>
+	              <option value="2">2</option>
+	              <option value="3">3</option>
+	              <option value="4+">4+</option>
 	            </Field>
-	            <label htmlFor="zip" name="zip">Zip Code</label>
+	            <label htmlFor="home_zip" name="home_zip">Zip Code</label>
 	          <Field
-	                    name="zip"
+	                    name="home_zip"
 	                    render={({ field }) => (
 	                      <MaskedInput
 	                        {...field}
@@ -115,7 +110,7 @@ const PageOne = props => (
 	            <button
 	              type="button"
 	              onClick={props.navigateNext}
-	              disabled={!(props.values.numberOnPolicy && props.values.zip)}
+	              disabled={!(props.values.numberOnPolicy && props.values.home_zip)}
 	            >
 	              Next
 	            </button>
@@ -125,7 +120,7 @@ const PageOne = props => (
 	              className="field-error"
 	            />
 	            <ErrorMessage
-	              name="zip"
+	              name="home_zip"
 	              component="div"
 	              className="field-error"
 	            />
@@ -176,7 +171,7 @@ const PageOne = props => (
 	              className="field-error"
 	            />
 	            <ErrorMessage
-	              name="zip"
+	              name="home_zip"
 	              component="div"
 	              className="field-error"
 	            />

--- a/src/routes/form/PageThree.js
+++ b/src/routes/form/PageThree.js
@@ -9,7 +9,7 @@ const PageThree = props => (
 		  <p>You may qualify for savings on your monthly based on your estimated household income.</p>
 		</div>
 		<label htmlFor="income" name="income">Annual Income</label>
-		<Field htmlFor="income" placholder="Annual Income" name="income"/>
+		<Field htmlFor="income" placholder="Annual Income" name="income" />
 		<ErrorMessage
 		  name="income"
 		  component="div"

--- a/src/routes/form/PageTwo.js
+++ b/src/routes/form/PageTwo.js
@@ -41,6 +41,7 @@ const PageTwo = props => (
 		/>
 		<label htmlFor="gender" name="gender">Gender</label>
 		<Field htmlFor="gender" placholder="Gender" component="select" name="gender">
+		  <option value="">Select</option>
 		  <option value="Male" name="gender">Male</option>
 		  <option value="Female" name="gender">Female</option>
 		</Field>
@@ -51,6 +52,7 @@ const PageTwo = props => (
 		/>
 		<label htmlFor="tobacco" name="tobacco">Tobacco user?</label>
 		<Field htmlFor="tobacco" placholder="Tobacco user?" component="select" name="tobacco">
+			<option value="">Select</option>
 		  <option value="Yes" name="tobacco">Yes</option>
 		  <option value="No" name="tobacco">No</option>
 		</Field>

--- a/src/routes/form/PageTwo.js
+++ b/src/routes/form/PageTwo.js
@@ -42,8 +42,8 @@ const PageTwo = props => (
 		<label htmlFor="gender" name="gender">Gender</label>
 		<Field htmlFor="gender" placholder="Gender" component="select" name="gender">
 		  <option value="">Select</option>
-		  <option value="Male" name="gender">Male</option>
-		  <option value="Female" name="gender">Female</option>
+		  <option value="M" name="gender">Male</option>
+		  <option value="F" name="gender">Female</option>
 		</Field>
 		<ErrorMessage
 		  name="gender"
@@ -53,8 +53,8 @@ const PageTwo = props => (
 		<label htmlFor="tobacco" name="tobacco">Tobacco user?</label>
 		<Field htmlFor="tobacco" placholder="Tobacco user?" component="select" name="tobacco">
 			<option value="">Select</option>
-		  <option value="Yes" name="tobacco">Yes</option>
-		  <option value="No" name="tobacco">No</option>
+		  <option value="1" name="tobacco">Yes</option>
+		  <option value="0" name="tobacco">No</option>
 		</Field>
 		<ErrorMessage
 		  name="tobacco"

--- a/src/routes/form/Wizard.js
+++ b/src/routes/form/Wizard.js
@@ -22,10 +22,10 @@ const SignUpSchema = Yup.object().shape({
   dateOfBirth: Yup.string()
     .required('Required'),
   gender: Yup.mixed()
-    .oneOf(['Male', 'Female'])
+    .oneOf(['M', 'F'])
     .required('Gender is required'),
   tobacco: Yup.mixed()
-    .oneOf(['Yes', 'No'])
+    .oneOf(['1', '0'])
     .required('Your tobacco usage is required.'),
   income: Yup.number()
     .required('Your income must be included'),
@@ -44,15 +44,15 @@ const SignUpSchema = Yup.object().shape({
     .required('Required'),
   // Apply mask
   phone_home: Yup.string()
-    .required('Phone number is required'),
+    .required('Phone number is required')
 });
 
 const initialValues = {
     numberOnPolicy: '1',
     home_zip: '90210',
     dateOfBirth: '12/12/1980',
-    gender: 'Male',
-    tobacco: 'No',
+    gender: 'M',
+    tobacco: '0',
     income: '33000',
     coverageType: 'Silver',
     name_first: 'John',
@@ -102,8 +102,8 @@ class Wizard extends Component {
         },
         body: data
       })
-      .then(function(res){ return res.json(); })
-      .then(function(data){ console.log( JSON.stringify( data ) ) })
+      .then((res) => res.json())
+      .then((data) => console.log(JSON.stringify(data)));
     }
 
     render() {

--- a/src/routes/form/Wizard.js
+++ b/src/routes/form/Wizard.js
@@ -15,7 +15,7 @@ const SignUpSchema = Yup.object().shape({
     .oneOf(['1', '2', '3', '4+'])
     .required('Please select'),
   // Apply mask
-  zip: Yup.string()
+  home_zip: Yup.string()
     .length(5)
     .required('Enter ZIP'),
   // Apply mask
@@ -32,40 +32,79 @@ const SignUpSchema = Yup.object().shape({
   coverageType: Yup.mixed()
     .oneOf(['Bronze', 'Silver', 'Gold', 'Platinum'])
     .required('Please select your coverage type.'),
-  firstName: Yup.string()
+  name_first: Yup.string()
     .required('Required'),
-  lastName: Yup.string()
+  name_last: Yup.string()
     .required('Required'),
-  // Apply mask 
-  streetAddress: Yup.string()
+  // Apply mask
+  home_street: Yup.string()
     .required('Please enter street address'),
   email: Yup.string()
     .email('Invalid email address')
     .required('Required'),
   // Apply mask
-  phone: Yup.string()
+  phone_home: Yup.string()
     .required('Phone number is required'),
 });
 
 const initialValues = {
-    numberOnPolicy: '',
-    zip: '',
-    dateOfBirth: '',
-    gender: '',
-    tobacco: '',
-    income: '',
-    coverageType: '',
-    firstName: '',
-    lastName: '',
-    streetAddress: '',
-    email: '',
-    phone: ''
+    numberOnPolicy: '1',
+    home_zip: '90210',
+    dateOfBirth: '12/12/1980',
+    gender: 'Male',
+    tobacco: 'No',
+    income: '33000',
+    coverageType: 'Silver',
+    name_first: 'John',
+    name_last: 'Doe',
+    home_street: 'Test Street 123',
+    email: 'test@test.com',
+    phone_home: '(555) 757-2923'
 };
 
 class Wizard extends Component {
+
     state = {
         pageIndex: 0
     };
+
+    handleSubmit = (values) => {
+      console.log('start submit');
+
+      // getting aff values
+      values.client_name= this.props.affid || 'HealthDefault';
+      values.sub_id1= this.props.sub_id1 || 's1';
+      values.sub_id2= this.props.sub_id2 || 's2';
+      values.sub_id3= this.props.sub_id3 || 's3';
+
+      // hardcoding some values
+      values.user_agent= 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3776.0 Safari/537.36';
+      values.ip_address = '127.0.0.1';
+      values.home_city = 'Beverly Hills';
+      values.home_state = 'CA';
+      values.datetime_collected = new Date().toISOString();
+
+      // get date of birth in correct format
+      const month = values.dateOfBirth.substr(0, 2);
+      const day = values.dateOfBirth.substr(3, 2);
+      const year = values.dateOfBirth.substr(6, 4);
+      values.dob = year + '-' + month + '-' + day;
+      delete values.dateOfBirth;
+
+      const data = Object.keys(values).map(k => `${encodeURIComponent(k)}=${encodeURIComponent(values[k])}`).join('&');
+      console.log('form data object: ', values);
+      console.log('form data query: ', data);
+
+      fetch('https://staging.one.pingtreetech.com/api/health/post', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8'
+        },
+        body: data
+      })
+      .then(function(res){ return res.json(); })
+      .then(function(data){ console.log( JSON.stringify( data ) ) })
+    }
 
     render() {
         return (
@@ -76,10 +115,10 @@ class Wizard extends Component {
 							initialValues={initialValues}
 							validationSchema={SignUpSchema}
 							onSubmit={(values, { setSubmitting }) => {
-								setTimeout(() => {
-									alert(JSON.stringify(values, null, 2));
+								// setTimeout(() => {
+									this.handleSubmit(values);
 									setSubmitting(false);
-								}, 1000);
+								// }, 1000);
 							}}
 						>
 							{props => {

--- a/src/routes/form/index.js
+++ b/src/routes/form/index.js
@@ -7,9 +7,9 @@ import * as Yup from 'yup';
 
 import Wizard from './Wizard';
 
-const App = () => (
+const App = (props) => (
 	<div className="app">
-		<Wizard />
+		<Wizard {...props} />
 	</div>
 );
 

--- a/src/style/_input-group.scss
+++ b/src/style/_input-group.scss
@@ -30,7 +30,7 @@ div.input-group {
 		border-bottom-left-radius: $base-border-radius;
 	}
 
-	input[name="zip"] {
+	input[name="home_zip"] {
 		border-radius: 0;
 		border-left: none;
 	}
@@ -45,7 +45,7 @@ div.input-group {
 
 	@media (min-width: 500px) {
 		grid-template-rows: 30px 1fr;
-		grid-template-columns: 1fr 1fr 1.5fr;	
+		grid-template-columns: 1fr 1fr 1.5fr;
 
 		input[type="number"] {
 			border-radius: 0;


### PR DESCRIPTION
@kylepfeeley @guyandy here's the posting to opt functionality flow with a couple of hardcoded values. we're getting the `affid`, `sub_id1`, `sub_id2` and `sub_id3` from the url, or passing default values. Still left to do is, if a user goes on some other page (privacy/terms), hits reload and then returns to the form page, those will be lost. I believe we can achieve this by using local storage. Also we need to get `universal_leadid` in, get `user_agent` and `ip_address` the proper way, extract `home_city` and `home_state` from `home_zip`, get maybe `offer_id` in, `trusted_form` and I think that about covers the whole posting part. Maybe we'll need some additional hidden fields, but this currently is getting a response from the staging opt `{"message":"","success":true,"payout":0.01}`